### PR TITLE
Use ldc inside checker in order to acomodate aarch64 users

### DIFF
--- a/Project/m1/db_conn/Makefile
+++ b/Project/m1/db_conn/Makefile
@@ -1,0 +1,18 @@
+start:
+	make -C ../docker start
+
+attach-to-logs:
+	make -C ../docker attach-to-logs
+
+# This will stop and delete the containers
+# Following this, make start will trigger a full rebuild
+stop:
+	make -C ../docker stop
+
+# This is the nuclear option
+# This will destroy all the containers and images
+# Following this, make start will have to rebuild the images, then trigger a full rebuild
+# Use with caution
+.PHONY: clean
+clean:
+	make -C ../docker clean

--- a/Project/m1/docker/Dockerfile
+++ b/Project/m1/docker/Dockerfile
@@ -1,32 +1,20 @@
 FROM ubuntu:latest
 
-ENV DMD=dmd-2.100.2
+ENV LDC=ldc-1.30.0
 
 ENV DEBIAN_FRONTEND="noninteractive"
 
 WORKDIR /checker
 
-COPY ./db_conn /checker
-
 RUN apt-get update
 
 RUN apt-get install -y build-essential
 
-RUN apt-get install -y libevent-dev libssl-dev
+RUN apt-get install -y libevent-dev libssl-dev libxml2 lzma-dev
 
 RUN apt-get install -y wget curl xz-utils
 
-RUN ["/bin/bash", "-c", "curl -fsS https://dlang.org/install.sh | bash -s $DMD"]
+RUN ["/bin/bash", "-c", "curl -fsS https://dlang.org/install.sh | bash -s $LDC"]
 
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
 RUN chmod +x /wait
-
-#RUN ["/bin/bash", "-c", "cd /checker && source ~/dlang/$DMD/activate && dub build"]
-
-# Wait for the mongo instance to be up and running
-#RUN WAIT_HOSTS=localhost:27017 ./wait &&\
-    #cd m1/db_conn &&\
-    #source ~/dlang/$DMD/activate &&\
-    #dub run
-
-#COPY ./checker ${CHECKER_DATA_DIRECTORY}

--- a/Project/m1/docker/Makefile
+++ b/Project/m1/docker/Makefile
@@ -2,8 +2,7 @@ build:
 	docker-compose build
 
 start: build
-	#docker-compose up -d
-	docker-compose run checker /usr/bin/bash -c '/wait && source ~/dlang/dmd-2.100.2/activate && dub run'
+	docker-compose up checker
 
 mongosh:
 	docker-compose exec mongo mongosh mongodb://root:example@mongo:27017/
@@ -11,7 +10,12 @@ mongosh:
 attach-to-logs:
 	docker-compose logs -f mongo
 
+stop:
+	docker-compose down
+
 .PHONY: clean
 clean:
 	docker rm -f `docker ps -a | grep "docker_mongo" | cut -f "1" -d ' '`
+	docker rm -f `docker ps -a | grep "docker_checker" | cut -f "1" -d ' '`
 	docker image rm -f `docker image ls | grep "docker_mongo" | tr -s ' ' | cut -f "3" -d ' '`
+	docker image rm -f `docker image ls | grep "docker_checker" | tr -s ' ' | cut -f "3" -d ' '`

--- a/Project/m1/docker/docker-compose.yml
+++ b/Project/m1/docker/docker-compose.yml
@@ -12,10 +12,10 @@ services:
         target: /checker
     environment:
       - WAIT_HOSTS=mongo:27017
-      - DMD=dmd-2.100.2
+      - LDC=ldc-1.30.0
     depends_on:
       - mongo
-    command: /usr/bin/bash -c '/wait && source ~/dlang/dmd-2.100.2/activate && dub run'
+    command: /usr/bin/bash -c '/wait && source ~/dlang/ldc-1.30.0/activate && dub run'
 
   mongo:
     image: mongo:5.0.13

--- a/docs/project/milestone-1.md
+++ b/docs/project/milestone-1.md
@@ -47,6 +47,14 @@ curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
 sudo apt-get install -y docker-compose
 ```
 
+You can add your user to the `docker` group in order to avoid having to use `sudo` when running docker commands:
+```bash
+sudo usermod -aG docker $USER
+```
+You need to log out and log back in so that your group membership is re-evaluated.
+If you’re running Linux in a virtual machine, it may be necessary to restart the virtual machine for changes to take effect.
+More details about this on the official [page](https://docs.docker.com/engine/install/linux-postinstall/).
+
 After you have installed a working version of docker on your system, you will need to run the provided makefile to set up the database.
 
 ```bash
@@ -86,6 +94,10 @@ cd docker && make start
 
 This will start a mongo container and a container that will build your project and run the checker against the mongo container.
 
+You can use the makefile from the `db_conn` directory to achieve the same thing:
+```bash
+cd db_conn && make start
+```
 
 ### Working with mongo-db from D
 


### PR DESCRIPTION
Also, add a `Makefile` inside the `db_conn` dir such that running `make start` from there will run the checker.