### PR TITLE
Clean up Mongo volumes on `make stop`

### DIFF
--- a/Project/m1/docker/Makefile
+++ b/Project/m1/docker/Makefile
@@ -11,7 +11,7 @@ attach-to-logs:
 	docker-compose logs -f mongo
 
 stop:
-	docker-compose down
+	docker-compose down -v
 
 .PHONY: clean
 clean:

--- a/Project/m2/docker/Makefile
+++ b/Project/m2/docker/Makefile
@@ -11,7 +11,7 @@ attach-to-logs:
 	docker-compose logs -f mongo
 
 stop:
-	docker-compose down
+	docker-compose down -v
 
 .PHONY: clean
 clean: stop


### PR DESCRIPTION
This is done by adding the `-v` argument to `docker-compose down`.